### PR TITLE
Closes #23 Link to live coder twitch page

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -5,6 +5,7 @@ import Nav from "../components/nav"
 import VertLogo from "../img/logo-vert.png"
 import GitHubLogo from "../img/icons/github-square-brands.svg"
 import TwitterLogo from "../img/icons/twitter-square-brands.svg"
+import TwitchLogo from "../img/icons/twitch-brands.svg"
 
 import "../css/footer.css"
 
@@ -16,7 +17,7 @@ export default () => (
         <img src={VertLogo} alt={"Live Coders Logo"} />
       </div>
       <div className="navigation">
-        <Nav />
+        <Nav isFooter={true} />
         <div>
           <a
             href="https://github.com/livecoders"
@@ -31,6 +32,13 @@ export default () => (
             rel="noopener noreferrer"
           >
             <img src={TwitterLogo} alt={"Twitter Logo"} />
+          </a>
+          <a
+            href="https://www.twitch.tv/team/livecoders"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src={TwitchLogo} alt={"Twitch Logo"} />
           </a>
         </div>
         <Link

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -3,7 +3,7 @@ import { Link } from "gatsby"
 
 import "../css/nav.css"
 
-export default () => (
+export default ({ isFooter }) => (
   <nav>
     <ul>
       <li>
@@ -15,6 +15,17 @@ export default () => (
       <li>
         <Link to={"/about"}>About</Link>
       </li>
+      {!isFooter && (
+        <li>
+          <a
+            href="https://www.twitch.tv/team/livecoders"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitch
+          </a>
+        </li>
+      )}
     </ul>
   </nav>
 )

--- a/src/css/footer.css
+++ b/src/css/footer.css
@@ -31,6 +31,11 @@ footer div.navigation div a {
   color: white;
 }
 
-footer div.navigation div a:first-child {
+footer div.navigation div a {
   margin-right: 20px;
+}
+
+footer div.navigation div a:last-child {
+  margin-right: 0;
+  padding-top: 2px;
 }


### PR DESCRIPTION
Had a short chat with @lannonbr about this.

There is a working, but possibly not-ideal, thing where we treat the header nav and footer nav slightly different. This is to avoid having BOTH the twitch link in words, and the twitch icon. Here is what it looks like:

<img width="411" alt="Screen Shot 2020-04-26 at 12 59 31 PM" src="https://user-images.githubusercontent.com/119065/80314303-bd702200-87be-11ea-8986-8c302c1eeadb.png">

<img width="337" alt="Screen Shot 2020-04-26 at 12 59 26 PM" src="https://user-images.githubusercontent.com/119065/80314304-c103a900-87be-11ea-8ccb-30670c71c10f.png">
