### PR TITLE
Add vanity domain for ordering jerseys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -57,3 +57,9 @@
   to = "https://livecoders-heatmap.netlify.app/"
   status = 301
   force = true
+
+[[redirects]]
+  from = "https://jerseys.livecoders.dev"
+  to = "https://customesports.com/product/official-live-coders-jersey/"
+  status = 301
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -60,6 +60,6 @@
 
 [[redirects]]
   from = "https://jerseys.livecoders.dev"
-  to = "https://customesports.com/product/official-live-coders-jersey/"
+  to = "https://customesports.com/product-category/team-store/the-live-coders/"
   status = 301
   force = true


### PR DESCRIPTION
Redirect jerseys.livecoders.dev to the Custom eSports order page for live coders jerseys.

Addresses issue #108.

Making PR a draft since I have a concern which needs to be addressed on the issue.