### PR TITLE
Regenerate homepage collage automagically

### DIFF
--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -18,6 +18,11 @@ jobs:
           cd scripts/genMembers
           npm install
           node index.js
+      - name: Recreate mission statement collage
+        run: |
+          cd scripts/genMissionStatementImage
+          npm install
+          node index.js
       - name: Commit changes & build site
         id: commit
         env:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.11",
     "@mdx-js/react": "^1.6.11",
+    "canvas": "^2.6.1",
     "date-fns": "^2.15.0",
     "gatsby": "^2.24.4",
     "gatsby-image": "^2.4.13",

--- a/scripts/genMissionStatementImage/index.js
+++ b/scripts/genMissionStatementImage/index.js
@@ -1,0 +1,64 @@
+const fs = require('fs')
+const path = require("path")
+const { createCanvas, loadImage } = require('canvas')
+const c = require('ansi-colors')
+
+// get all member images
+let memberImages = fs.readdirSync(path.join(__dirname, "..", "..", "src", "img", "members"))
+
+console.log(c.cyan(`Identified ${memberImages.length} member images`))
+
+if (memberImages.length > 0) {
+
+  // shuffle the images randomly
+  for (let i = memberImages.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [memberImages[i], memberImages[j]] = [memberImages[j], memberImages[i]];
+  }
+
+  // pull 64 images from shuffled list
+  memberImages = memberImages.slice(0, 64)
+
+  console.log(c.cyan('Randomly selected 64 member images. They are:'))
+  memberImages.forEach((fileName) => console.log(c.green(fileName.split(".").shift())))
+
+  // create canvas for the final image
+  const canvas = createCanvas(1600, 400)
+  const context = canvas.getContext('2d')
+
+  context.beginPath();
+  context.rect(0, 0, 1600, 400);
+  context.fillStyle = "#2C1643";
+  context.fill();
+
+  let xPos = 0, yPos = 0
+
+  // load all images
+  Promise.all(
+    memberImages.map((fileName) =>
+      loadImage(path.join(__dirname, "..", "..", "src", "img", "members", fileName)))
+  ).then((images) => {
+
+    // for each image, draw to canvas
+    for (let i = 0; i < images.length; i++) {
+
+      context.drawImage(images[i], xPos + 1, yPos + 1, 98, 98)
+
+      // shift x & y positions
+      if (((i + 1) % 16) === 0) {
+        yPos += 100
+      }
+      if (xPos === 1500) {
+        xPos = 0
+      } else {
+        xPos += 100
+      }
+    }
+
+    // save the file out to disk
+    const out = fs.createWriteStream(path.join(__dirname, "..", "..", "src", "img", "livecoders-collage.png"))
+    const stream = canvas.createPNGStream()
+    stream.pipe(out)
+    out.on('finish', () => console.log('The PNG file was created.'))
+  })
+}

--- a/scripts/genMissionStatementImage/package-lock.json
+++ b/scripts/genMissionStatementImage/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "genmissionstatementimage",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "merge-images": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-images/-/merge-images-2.0.0.tgz",
+      "integrity": "sha512-bpI4j54n/Zl6ZTgxaR3xWou/lqI53RAAt8peXijW37BKqoON83LQ7XCZqtFiwzBfEXIws1isYyR06584yffAyA=="
+    }
+  }
+}

--- a/scripts/genMissionStatementImage/package.json
+++ b/scripts/genMissionStatementImage/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "genmissionstatementimage",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ansi-colors": "^4.1.1",
+    "merge-images": "^2.0.0"
+  }
+}


### PR DESCRIPTION
During the nightly user update GitHub Action (or on demand), we'll get all images for members, randomly shuffle them and choose 64 to generate the mission statement collage. The action will also log each member it chose so we can review in the future to ensure randomness.