### PR TITLE
Add links to reporting CoC violations

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -66,8 +66,9 @@ export default () => (
               </a>
             </div>
             <Link to="/coc/" className="foot-coc">
-              Code of Conduct
+              Code of Conduct (Report Violation)
             </Link>
+
             <span className="f-awesome-attribute">
               Icons by{" "}
               <a href="https://fontawesome.com/license/free">Font Awesome</a>

--- a/src/pages/coc.js
+++ b/src/pages/coc.js
@@ -16,6 +16,15 @@ export default () => (
     </div>
     <section id="codeOfConduct">
       <h2>General</h2>
+      <a
+        href="https://forms.gle/9yyiB7xQMX6CES9n9"
+        target="_blank"
+        rel="noreferrer"
+        style={{ color: "#FFF" }}
+      >
+        To report a violation, please reach out here.(Report Violation)
+      </a>
+
       <ul>
         <li>
           Be kind and welcoming to new viewers in your stream, other viewers in
@@ -158,6 +167,14 @@ export default () => (
           etc. please reach out to Community Manager LilyHazel.
         </li>
       </ul>
+      <a
+        href="https://forms.gle/9yyiB7xQMX6CES9n9"
+        target="_blank"
+        rel="noreferrer"
+        style={{ color: "#FFF" }}
+      >
+        To report a violation, please reach out here.(Report Violation)
+      </a>
     </section>
     <Footer />
   </React.Fragment>


### PR DESCRIPTION
There is a persistent "note" in the footer.

There are now two links in two places on the code of conduct page. Screenshots below:

![Screen Shot 2021-01-25 at 5 27 31 PM](https://user-images.githubusercontent.com/119065/105774284-1a0d9280-5f33-11eb-91c5-5701f28ecf63.png)

![top-level](https://user-images.githubusercontent.com/119065/105774335-2a257200-5f33-11eb-9fb5-a2c0e30e53c9.png)

![end-of-doc](https://user-images.githubusercontent.com/119065/105774364-2eea2600-5f33-11eb-8eed-386fd00c3342.png)
