### PR TITLE
Fixing build workflow by stickying versions of build environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   gatsby-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Removing locks
@@ -23,7 +23,7 @@ jobs:
           name: public-dir
           path: public/
   gen-og-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Build files
@@ -39,7 +39,7 @@ jobs:
           path: scripts/genOGImages/dist/members/
   deploy-build:
     needs: [gen-og-images, gatsby-build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: get public dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Build files
         run: |
           cd scripts/genOGImages

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -4,41 +4,41 @@ on:
     - cron: "1 0 * * *"
   workflow_dispatch:
 jobs:
-  run-gen-members:
-    runs-on: ubuntu-20.04
-    outputs:
-      members_updated: ${{ steps.commit.outputs.members_updated }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-      - name: Update member list
-        env:
-          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
-          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
-        run: |
-          cd scripts/genMembers
-          npm install
-          node index.js
-      - name: Recreate mission statement collage
-        run: |
-          cd scripts/genMissionStatementImage
-          npm install
-          node index.js
-      - name: Commit changes & build site
-        id: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+#  run-gen-members:
+#    runs-on: ubuntu-20.04
+#    outputs:
+#      members_updated: ${{ steps.commit.outputs.members_updated }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-node@v3
+#        with:
+#          node-version: 16
+#          cache: 'npm'
+#      - name: Update member list
+#        env:
+#          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+#          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+#        run: |
+#          cd scripts/genMembers
+#          npm install
+#          node index.js
+#      - name: Recreate mission statement collage
+#        run: |
+#          cd scripts/genMissionStatementImage
+#          npm install
+#          node index.js
+#      - name: Commit changes & build site
+#        id: commit
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          git config user.name "GitHub Actions Bot"
+#          git config user.email "<>"
 
-          git pull origin master
-          git add .
-          git commit -m "Updating members" && echo "::set-output name=members_updated::true" || echo "::set-output name=members_updated::false"
-          git push origin master
+#          git pull origin master
+#          git add .
+#          git commit -m "Updating members" && echo "::set-output name=members_updated::true" || echo "::set-output name=members_updated::false"
+#          git push origin master
   build-site:
     runs-on: ubuntu-latest
     if: contains(needs.run-gen-members.outputs.members_updated, true)
@@ -68,7 +68,7 @@ jobs:
   gen-og-images:
     runs-on: ubuntu-latest
     if: contains(needs.run-gen-members.outputs.members_updated, true)
-    needs: [run-gen-members]
+#    needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   run-gen-members:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       members_updated: ${{ steps.commit.outputs.members_updated }}
     steps:

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -10,6 +10,10 @@ jobs:
       members_updated: ${{ steps.commit.outputs.members_updated }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Update member list
         env:
           TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -4,45 +4,44 @@ on:
     - cron: "1 0 * * *"
   workflow_dispatch:
 jobs:
-#  run-gen-members:
-#    runs-on: ubuntu-20.04
-#    outputs:
-#      members_updated: ${{ steps.commit.outputs.members_updated }}
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version: 16
-#          cache: 'npm'
-#      - name: Update member list
-#        env:
-#          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
-#          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
-#        run: |
-#          cd scripts/genMembers
-#          npm install
-#          node index.js
-#      - name: Recreate mission statement collage
-#        run: |
-#          cd scripts/genMissionStatementImage
-#          npm install
-#          node index.js
-#      - name: Commit changes & build site
-#        id: commit
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          git config user.name "GitHub Actions Bot"
-#          git config user.email "<>"
-
-#          git pull origin master
-#          git add .
-#          git commit -m "Updating members" && echo "::set-output name=members_updated::true" || echo "::set-output name=members_updated::false"
-#          git push origin master
+  run-gen-members:
+    runs-on: ubuntu-20.04
+    outputs:
+      members_updated: ${{ steps.commit.outputs.members_updated }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Update member list
+        env:
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+        run: |
+          cd scripts/genMembers
+          npm install
+          node index.js
+      - name: Recreate mission statement collage
+        run: |
+          cd scripts/genMissionStatementImage
+          npm install
+          node index.js
+      - name: Commit changes & build site
+        id: commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git pull origin master
+          git add .
+          git commit -m "Updating members" && echo "::set-output name=members_updated::true" || echo "::set-output name=members_updated::false"
+          git push origin master
   build-site:
     runs-on: ubuntu-latest
-#    if: contains(needs.run-gen-members.outputs.members_updated, true)
-    #needs: [run-gen-members]
+    if: contains(needs.run-gen-members.outputs.members_updated, true)
+    needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -67,8 +66,8 @@ jobs:
           path: public/
   gen-og-images:
     runs-on: ubuntu-latest
-#    if: contains(needs.run-gen-members.outputs.members_updated, true)
-#    needs: [run-gen-members]
+    if: contains(needs.run-gen-members.outputs.members_updated, true)
+    needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -41,7 +41,7 @@ jobs:
 #          git push origin master
   build-site:
     runs-on: ubuntu-latest
-    if: contains(needs.run-gen-members.outputs.members_updated, true)
+#    if: contains(needs.run-gen-members.outputs.members_updated, true)
     #needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
           path: public/
   gen-og-images:
     runs-on: ubuntu-latest
-    if: contains(needs.run-gen-members.outputs.members_updated, true)
+#    if: contains(needs.run-gen-members.outputs.members_updated, true)
 #    needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/gen-members.yml
+++ b/.github/workflows/gen-members.yml
@@ -42,11 +42,15 @@ jobs:
   build-site:
     runs-on: ubuntu-latest
     if: contains(needs.run-gen-members.outputs.members_updated, true)
-    needs: [run-gen-members]
+    #needs: [run-gen-members]
     steps:
       - uses: actions/checkout@v2
         with:
           ref: master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Removing locks
         run: rm package-lock.json
       - name: Install dependencies
@@ -69,6 +73,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Build files
         run: |
           cd scripts/genOGImages


### PR DESCRIPTION
As of node17, there was a security protocol change which disabled our build process. While reverting to an older version might not be the prettiest solution, it does appear to work.

**Important note**
This has been run in parts in my branch, but not in full as I lack both twitch & netlify keys and setting it up felt overkill. It's in the world of "should work", which isn't great, but since it's completely broken ATM, worst case it'll stop at a later error in the flow.